### PR TITLE
Change current lauch local date timezone

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,6 +19,7 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
@@ -124,7 +125,13 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip
+            label={formatDateTime(launch.launch_date_local)}
+            placement="top"
+            aria-label='Information of the launch date on your timezone'
+          >
+            {formatDateTime(launch.launch_date_utc)}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>


### PR DESCRIPTION
Launch datetime on the launch details page were displayed in the timezone of the app's user. We keep this extra information as a tooltip and show the local timezone of the launch site instead.